### PR TITLE
fix php8.4 deprecated warning

### DIFF
--- a/src/IndexNow.php
+++ b/src/IndexNow.php
@@ -62,7 +62,7 @@ class IndexNow
      *
      * @throws Exception
      */
-    public function delaySubmission(string|array $url, int $delayInSeconds = null): PendingDispatch
+    public function delaySubmission(string|array $url, ?int $delayInSeconds = null): PendingDispatch
     {
         $delayInSeconds ??= (int) config('index-now.delay');
 


### PR DESCRIPTION
fixes

```
PHP Deprecated:  LaravelFreelancerNL\LaravelIndexNow\IndexNow::delaySubmission(): Implicitly marking parameter $delayInSeconds as nullable is deprecated, the explicit nullable type must be used instead in ./src/IndexNow.php on line 65
```